### PR TITLE
TASK: Use translation for comment info „Created at“

### DIFF
--- a/Resources/Private/Fusion/Component/Comment.fusion
+++ b/Resources/Private/Fusion/Component/Comment.fusion
@@ -16,7 +16,7 @@ prototype(Breadlesscode.Commentable:Component.Comment) < prototype(Neos.Fusion:C
             }
             createdAt = Neos.Fusion:Tag {
                 tagName = 'p'
-                content = ${ 'Created at: ' + Date.format(props.createdAt, 'd.m.Y H:i') }
+                content = ${ Translation.translate('Breadlesscode.Commentable:NodeTypes.Content.Comment:properties.createdAt') + ': ' + Date.format(props.createdAt, 'd.m.Y H:i') }
             }
         }
         attributes.class = 'comment'


### PR DESCRIPTION
This PR adds translation for the label "Created at" for comments. Translation is taken from the property translation.